### PR TITLE
change the "good" method parameter indentation to two spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ You can generate a PDF or an HTML copy of this guide using
     end
     ```
 
-* Align the parameters of a method call if they span over multiple lines.
+* Indent the parameters of a method call with two spaces if they span over multiple lines. 
+  Optionally place the trailing `)` on its own line returning to the parent indentation.
 
     ```Ruby
     # starting point (line is too long)
@@ -165,13 +166,12 @@ You can generate a PDF or an HTML copy of this guide using
       Mailer.deliver(to: 'bob@example.com', from: 'us@example.com', subject: 'Important message', body: source.text)
     end
 
-    # bad (normal indent)
+    # bad (large indent aligning with the method's open-parenthesis) 
     def send_mail(source)
-      Mailer.deliver(
-        to: 'bob@example.com',
-        from: 'us@example.com',
-        subject: 'Important message',
-        body: source.text)
+      Mailer.deliver(to: 'bob@example.com',
+                     from: 'us@example.com',
+                     subject: 'Important message',
+                     body: source.text)
     end
 
     # bad (double indent)
@@ -183,12 +183,23 @@ You can generate a PDF or an HTML copy of this guide using
           body: source.text)
     end
 
-    # good
+    # good (two space indent)
     def send_mail(source)
-      Mailer.deliver(to: 'bob@example.com',
-                     from: 'us@example.com',
-                     subject: 'Important message',
-                     body: source.text)
+      Mailer.deliver(
+        to: 'bob@example.com',
+        from: 'us@example.com',
+        subject: 'Important message',
+        body: source.text)
+    end
+
+    # good (two space indent with close parenthesis returning to parent indent)
+    def send_mail(source)
+      Mailer.deliver(
+        to: 'bob@example.com',
+        from: 'us@example.com',
+        subject: 'Important message',
+        body: source.text
+      )
     end
     ```
 


### PR DESCRIPTION
don't merge. I know various people don't agree with the changes in this PR, and I want to solicit discussion. 

this changes the standard for spacing on multiline method parameters to a two space indent. not aligned with the method call above, just two spaces. 

``` ruby
some_object.some_method(
  arg1,
  :option1 => value1,
  :option2 => value2
)
```

and nested:

``` ruby
some_object.some_method(
  arg1,
  :option1 => value1,
  :option2 => more_nested_method(
    nested_arg_one,
    nested_arg_two
  )
)
```

placement of the closing `)` can be on a new line, as above, or at the end of the last line. 

advantages of this are:
- this does not require reformatting subsequent lines when the method call on the first line changes
- two-space indentation allows for better usage of the line, with less wrapping, whereas the available space drops drastically when aligning with the method call. dr. albers demonstrates this nicely in these commits (especially the first)
  - https://github.com/mdsol/checkmate/commit/0431ce4
  - https://github.com/mdsol/checkmate/commit/fedf97d#L1R24
- this looks nicer. aligning with the method above is super ugly. also demonstrated by chad's commits (again especially the first) 
- this is in line with the indentation on multiline hashes, like

``` ruby
some_hash = {
  :key1 => value1,
  :key2 => value2,
  :key3 => {
    :nested_key_a => value_a,
    :nested_key_b => value_b
  }
}
```

that isn't actually in this style guide, but it seems fairly standard, and sensible. I'm sure there are people who do ridiculous things with indentation on hashes too though. 
