### PR TITLE
Avoid comparing booleans to boolean constants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,23 @@ You can generate a PDF or an HTML copy of this guide using
     # good
     arr.each { |elem| puts elem }
     ```
+* Avoid comparing booleans to boolean constants.
+
+	```Ruby
+	# bad
+	if condition == true
+	
+	# good
+	if condition
+	
+	# bad
+	options[:verbose] = true
+	puts "Loading…" unless options[:verbose] == false
+	
+	# good
+	options[:silent] = false
+	puts "Loading…" unless options[:silent]
+	```
 
 * Never use `then` for multi-line `if/unless`.
 


### PR DESCRIPTION
Not particularly Ruby-specific, but I've seen violations of it in our code and they always set my teeth on edge.
