### PR TITLE
When to omit parentheses around method invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ You can generate a PDF or an HTML copy of this guide using
   internal DSL (e.g. Rake, Rails, RSpec), methods that are with
   "keyword" status in Ruby (e.g. `attr_reader`, `puts`) and attribute
   access methods. Use parentheses around the arguments of all other
-  method invocations.
+  method invocations. <PROVIDE MORE CLARIFICATION HERE>
 
     ```Ruby
     class Person


### PR DESCRIPTION
**DO NOT MERGE.**

I am looking to get people's opinions on how to provide more clarity on the following guideline:

- Omit parentheses around parameters for methods that are part of an internal DSL (e.g. Rake, Rails, RSpec), methods that have "keyword" status in Ruby (e.g. attr_reader, puts) and attribute access methods. Use parentheses around the arguments of all other method invocations.

What would be considered part of the Rails internal DSL? Are methods like `link_to` or `I18n.t` considered part of the Rails internal DSL?

Do we even agree with this guideline? Or should we modify it accordingly?

I posted this question on stackoverflow and have received some feedback http://stackoverflow.com/questions/17197316/ruby-on-rails-style-guidelines-parentheses-around-method-parameters