### PR TITLE
Fix formatting of the core.autocrlf configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ You can generate a PDF or an HTML copy of this guide using
     configuration setting to protect your project from Windows line
     endings creeping in:
 
-        ```$ git config --global core.autocrlf true```
+    ```Shell
+    $ git config --global core.autocrlf true
+    ```
 
 * Use spaces around operators, after commas, colons and semicolons, around `{`
   and before `}`. Whitespace might be (mostly) irrelevant to the Ruby


### PR DESCRIPTION
Added line breaks and tweaked the indentation so that it would render correctly (it was rendering the backquotes), and added the `Shell` format indicator.